### PR TITLE
Make sure old_state is not null

### DIFF
--- a/node-server-state-changed/node-server-state-changed.js
+++ b/node-server-state-changed/node-server-state-changed.js
@@ -43,7 +43,11 @@ const _int = {
             };
 
             if (shouldIncludeEvent) {
-                node.debug(`Incoming state event: entity_id: ${event.entity_id}, new_state: ${event.new_state.state}, old_state: ${event.old_state.state}`);
+                if (event.old_state) {
+                    node.debug(`Incoming state event: entity_id: ${event.entity_id}, new_state: ${event.new_state.state}, old_state: ${event.old_state.state}`);
+                } else {
+                    node.debug(`Incoming state event: entity_id: ${event.entity_id}, new_state: ${event.new_state.state}`);
+                }
                 nodeUtils.flashAttentionStatus(node, { appendMsg: event.new_state.state });
                 node.send(msg);
             }


### PR DESCRIPTION
Fixes the crash locally.  I'm not versed in the code enough to know if adding the check for (!event.old_state) up at the top of the function would cause any serious problems but this way the code before this debug still runs

Related to #5 
