### PR TITLE
Preserve original msg object when passing through "current state" node

### DIFF
--- a/node-api_current-state/node-api_current-state.js
+++ b/node-api_current-state/node-api_current-state.js
@@ -33,7 +33,10 @@ const _int = {
             return null;
         }
 
-        node.send({ topic: entity_id, payload: currentState.state, data: currentState });
+        msg.topic = entity_id;
+        msg.payload = currentState.state;
+        msg.data = currentState;
+        node.send(msg);
     }
 };
 


### PR DESCRIPTION
This is a simple change which simply adds the `topic`, `payload` and `data` properties to the original `msg` object before returning it, instead of creating a brand new object containing only those 3 properties.

This is done so that any properties in the original `msg` object are preserved and returned when going through the "current state" node. Another benefit is that the ID of the message (contained in the `msg._id` property) is not reset when going through this node. This is more inline with the expected behavior from Node-RED nodes.