### PR TITLE
Preserve original msg object when passing through "current state" node

### DIFF
--- a/nodes/api_current-state/api_current-state.js
+++ b/nodes/api_current-state/api_current-state.js
@@ -48,7 +48,10 @@ module.exports = function(RED) {
                 return null;
             }
 
-            this.node.send({ topic: entity_id, payload: currentState.state, data: currentState });
+            msg.topic = entity_id;
+            msg.payload = currentState.state;
+            msg.data = currentState;
+            this.node.send(msg);
         }
     }
 

--- a/nodes/api_current-state/api_current-state.js
+++ b/nodes/api_current-state/api_current-state.js
@@ -48,10 +48,10 @@ module.exports = function(RED) {
                 return null;
             }
 
-            msg.topic = entity_id;
-            msg.payload = currentState.state;
-            msg.data = currentState;
-            this.node.send(msg);
+            message.topic = entity_id;
+            message.payload = currentState.state;
+            message.data = currentState;
+            this.node.send(message);
         }
     }
 


### PR DESCRIPTION
This is a simple change which simply adds the `topic`, `payload` and `data` properties to the original `msg` object before returning it, instead of creating a brand new object containing only those 3 properties.

This is done so that any properties in the original `msg` object are preserved and returned when going through the "current state" node. Another benefit is that the ID of the message (contained in the `msg._id` property) is not reset when going through this node. This is more inline with the expected behavior from Node-RED nodes.