### PR TITLE
fix bug where override == false is forced to true

### DIFF
--- a/nodes/api_current-state/api_current-state.js
+++ b/nodes/api_current-state/api_current-state.js
@@ -51,8 +51,8 @@ module.exports = function(RED) {
             }
 
             // default switches to true if undefined (backward compatibility
-            const override_topic = this.nodeConfig.override_topic || true;
-            const override_payload = this.nodeConfig.override_payload || true;
+            const override_topic = this.nodeConfig.override_topic !== false;
+            const override_payload = this.nodeConfig.override_payload !== false;
 
             if (override_topic)   message.topic = entity_id;
             if (override_payload) message.payload = currentState.state;


### PR DESCRIPTION
Hi,

If the user clears the flag for override_topic/payload in the UI, the `|| true` forces it back to `true`, so these flags are always `true` regardless of user inputs.  This change results in `true` for anything except `false`. That is, `undefined`, `{}` or `true` become `true`, which I think is your intent - and the behavior I'm trying to get when I clear the flag.

Thanks,
Benjamin