### PR TITLE
Making overwrite switches disabled state work

### DIFF
--- a/nodes/api_current-state/api_current-state.js
+++ b/nodes/api_current-state/api_current-state.js
@@ -50,9 +50,9 @@ module.exports = function(RED) {
                 return null;
             }
 
-            // default switches to true if undefined (backward compatibility
-            const override_topic = this.nodeConfig.override_topic || true;
-            const override_payload = this.nodeConfig.override_payload || true;
+            // default switches to true if undefined (backward compatibility)
+            const override_topic = this.nodeConfig.override_topic !== false;
+            const override_payload = this.nodeConfig.override_payload !== false;
 
             if (override_topic)   message.topic = entity_id;
             if (override_payload) message.payload = currentState.state;


### PR DESCRIPTION
Overwrite switches did not work for me when i wanted the original payload to persist. I guess that the disabled state of the switches will result into `nodeConfig.override_topic` is `false` so the fallback pipe didn't work as expected.